### PR TITLE
Hotfix/remove blocking filter

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,2 @@
 @Library(value='jenkins-pipeline-library@main', changelog=false) _
-pipelineVIRUSSEQSingularity()
+pipelineIMicroSeqSingularity()

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.cancogen-virus-seq</groupId>
     <artifactId>singularity</artifactId>
-    <version>0.6.8</version>
+    <version>0.6.9</version>
     <name>singularity</name>
     <description>Singularity - All contributors, All files</description>
     <properties>

--- a/src/main/java/org/cancogenvirusseq/singularity/components/hoc/ArchiveBuildRequestToArchive.java
+++ b/src/main/java/org/cancogenvirusseq/singularity/components/hoc/ArchiveBuildRequestToArchive.java
@@ -54,12 +54,10 @@ public class ArchiveBuildRequestToArchive implements Function<ArchiveBuildReques
         .apply(archiveBuildRequest.getQueryBuilder())
         .transform(downloadMolecularDataToPair)
         .transform(createFileBundleFromPairsWithArchive(archiveBuildRequest.getArchive()))
-        .filter(fileBundlePath ->
+        .filterWhen(fileBundlePath ->
             archivesRepo
                 .findByArchiveObject(archiveBuildRequest.getArchive())
-                .filter(archive -> ArchiveStatus.BUILDING.equals(archive.getStatus()))
-                .hasElement()
-                .block()
+                .map(archive -> ArchiveStatus.BUILDING.equals(archive.getStatus()))
         )
         .flatMap(fileBundleUpload)
         .flatMap(


### PR DESCRIPTION
# Summary
This PR removes a blocking call in a reactive pipeline, instead it uses a non-blocking map function.

## Description of the issue
Unable to build bundle archives (metadata + manifest) when using custom filters from the Portal Explorer. The download modal displays a failure message, and the archive is not produced.

Server logs show the following error:
```
processArchiveBuildRequest error: block()/blockFirst()/blockLast() are blocking, which is not supported in thread reactor-http-epoll-6
```